### PR TITLE
Update head.swig

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -88,7 +88,7 @@
     fancybox: {{ theme.fancybox }},
     motion: {{ theme.use_motion }},
     duoshuo: {
-      userId: {{ theme.duoshuo_info.user_id | default() }},
+      userId: '{{ theme.duoshuo_info.user_id | default() }}',
       author: '{{ theme.duoshuo_info.admin_nickname | default(__('author'))}}'
     }
   };


### PR DESCRIPTION
 多说这里的userId没有引号，一些情况下没有被当成字符串，浏览器会报对象未定义的错误，应该被当做字符串处理加上引号就不会出错了
没有引号时浏览器会报错，图片
![](http://od6ri688q.bkt.clouddn.com/%E5%A4%9A%E8%AF%B4%E9%85%8D%E7%BD%AE%E7%96%91%E4%BC%BCbugQQ%E5%9B%BE%E7%89%8720160908233001.png)
