### PR TITLE
Repair error,update gulpfile

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -6,7 +6,7 @@ gulp.task 'lint', ->
   return gulp.src([
     './source/js/src/utils.js',
     './source/js/src/motion.js',
-    './source/js/src/hook-duoshuo.js'
+    './source/js/src/hook-duoshuo.js',
     './source/js/src/bootstrap.js',
     './source/js/src/post-details.js',
     './source/js/src/schemes/pisces.js'


### PR DESCRIPTION
 这里gulp.src()里面的数组元素hook-duoshuo.js后面少了一个逗号，会构建失败,加上即可
